### PR TITLE
HDDS-4938. Provide testkrb5 image for faster ozonesecure tests

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+github:
+  description: "Container image to provide MIT krb5 server for developing and testing Apache Ozone"
+  homepage: https://ozone.apache.org
+  labels:
+    - ozone
+    - container
+    - devtool
+    - unsecure
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+notifications:
+  commits:      commits@ozone.apache.org
+  issues:       issues@ozone.apache.org
+  pullrequests: issues@ozone.apache.org
+  jira_options: link label worklog

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What changes were proposed in this pull request?
+
+(Please fill in changes proposed in this fix)
+
+## What is the link to the Apache JIRA
+
+(Please create an issue in ASF JIRA before opening a pull request,
+and you need to set the title of the pull request which starts with
+the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)
+
+Please replace this section with the link to the Apache JIRA)
+
+## How was this patch tested?
+
+(Please explain how this patch was tested. Ex: unit tests, manual tests)
+(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: checkout source
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: build image
         run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: build
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    name: build and deploy
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout source
+        uses: actions/checkout@master
+      - name: build image
+        run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+For detailed contribution guideline, please check the [contribution guideline of Apache Ozone repository](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.13.2
+# hadolint ignore=DL3018
+RUN apk add --no-cache bash ca-certificates openssl krb5-server krb5 wget && update-ca-certificates && \
+   wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \
+   chmod +x /usr/local/bin/dumb-init
+WORKDIR /opt
+COPY krb5.conf /etc/
+COPY kadm5.acl /var/lib/krb5kdc/kadm5.acl
+COPY init.sh .
+RUN chmod +x ./init.sh && ./init.sh
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Containerized MIT Kerberos server for Ozone dev environments
 
-This repository containers the container definition of a MIT Kerberos server.
+This repository contains the definition of a containerized MIT Kerberos server.
 
 It's used for development and testing Apache Ozone and **not secured for production use**.
 
 Keytabs required by secure Ozone smoketests are pre-generated which makes possible to export them and store together with the containerized test environments. It makes the tests faster as the keytabs are already exported for each tests.
-
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Containerized MIT Kerberos server for Ozone dev environments
+
+This repository containers the container definition of a MIT Kerberos server.
+
+It's used for development and testing Apache Ozone and **not secured for production use**.
+
+Keytabs required by secure Ozone smoketests are pre-generated which makes possible to export them and store together with the containerized test environments. It makes the tests faster as the keytabs are already exported for each tests.
+
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+This container image (`apache/ozone-testkrb5`) is indented to be used only in *test and dev* environment. Please don't use it in production environment.
+
+The process of reporting Apache Ozone vulnerabilities [defined in the main Apache Ozone repository](https://github.com/apache/ozone/blob/master/SECURITY.md).

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+kdb5_util create -s -P Welcome1
+
+kadmin.local -q "addprinc -randkey admin/admin@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey scm/scm@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/scm@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey testuser/scm@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey testuser2/scm@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey recon/recon@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/recon@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey s3g/s3g@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/s3g@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey testuser/s3g@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey om/om@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/om@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey testuser/om@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey dn/dn@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/dn@EXAMPLE.COM"
+
+#for Mapreduce tests (Yarn):
+kadmin.local -q "addprinc -randkey jhs/jhs@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/jhs@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey rm/rm@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/rm@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey nm/nm@EXAMPLE.COM"
+kadmin.local -q "addprinc -randkey HTTP/nm@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey hadoop/rm@EXAMPLE.COM"
+
+kadmin.local -q "addprinc -randkey HTTP/ozone@EXAMPLE.COM"

--- a/kadm5.acl
+++ b/kadm5.acl
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+*/admin@EXAMPLE.COM x

--- a/krb5.conf
+++ b/krb5.conf
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[logging]
+default = STDERR
+kdc = STDERR
+admin_server = STDERR
+
+[libdefaults]
+ dns_canonicalize_hostname = false
+ dns_lookup_realm = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+ rdns = false
+ default_realm = EXAMPLE.COM
+
+[realms]
+ EXAMPLE.COM = {
+  kdc = localhost
+  admin_server = localhost
+  max_renewable_life = 7d
+ }
+
+[domain_realm]
+ .example.com = EXAMPLE.COM
+ example.com = EXAMPLE.COM
+


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-4938

Today ozonesecure compose clusters (and ozonesecure-ha and ozonesecure-mr) use an adhoc keytab issuer. The issuer is download during the [image creation](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/compose/common/docker-image/docker-krb5/Dockerfile-krb5) and uses a [third party](https://github.com/flokkr/issuer) go lang application to create the keytabs on-demand. 

As discussed earlier, it would be faster to use a dedicacated, pre-built container image which includes the pre-created keytabs instead of issuing them on-the fly.

For each of the tagged images we can export to current keytabs to `hadoop-ozone/dist/src/main/compose/` which can be mounted to the compose clusters.

It makes the overall acceptance test faster (instead of creating keytab, which is quite slow, we can start the cluster immediately). And we don't need to depend on an external utility app.

Pre-created keytabs are also more similar to production environment...