### PR TITLE
HDDS-11632. Publish images to GitHub container repo

### DIFF
--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: build-and-tag
+
+# This workflow builds (if necessary) and tags the Docker image.
+
+on:
+  push:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+
+  tag:
+    needs: build
+    if: ${{ github.ref_type == 'tag' }}
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_ID: ${{ needs.build.outputs.image-id }}
+    steps:
+      - name: Generate tags
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/ozone-testkrb5
+          tags: |
+            type=ref,event=tag
+          flavor: |
+            latest=false
+
+      - name: Pull image
+        run: |
+          docker pull "$IMAGE_ID"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply tags to existing image
+        run: |
+          opts="$(echo "$DOCKER_METADATA_OUTPUT_TAGS" | sed "s@^@--tag @g" | xargs echo)"
+          if [[ -n "$opts" ]]; then
+            docker buildx imagetools create $opts "$IMAGE_ID"
+          fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,16 +12,79 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 name: build
+
+# This workflow builds the Docker image if it does not exists already.
+# For non-PR runs, it also publishes the image to the registry, tagging it by the full SHA of the commit.
+
 on:
-  - push
-  - pull_request
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  workflow_call:
+    outputs:
+      image-id:
+        description: "Docker image ID in repo/owner/name:tag format"
+        value: ${{ jobs.build.outputs.image-id }}
+
+concurrency:
+  group: ${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
-    name: build and deploy
     runs-on: ubuntu-latest
+    outputs:
+      image-id: ${{ steps.meta.outputs.tags }}
     steps:
-      - name: checkout source
-        uses: actions/checkout@v4
-      - name: build image
-        run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]' | sed 's/docker-//g') .
+      - name: Generate image ID
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/ozone-testkrb5
+          tags: |
+            # keep single item
+            # any further tags should be added only in build-and-tag.yaml, not here
+            type=sha,prefix=,format=long
+
+      - name: Check if image exists
+        id: pull
+        run: |
+          success=false
+          if docker pull "$DOCKER_METADATA_OUTPUT_TAGS"; then
+            success=true
+          fi
+
+          echo "success=$success" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+
+      - name: Login to GitHub Container Registry
+        id: login
+        if: ${{ github.event_name != 'pull_request' && steps.pull.outputs.success == 'false' }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to GitHub Container Registry
+        id: build
+        if: ${{ steps.pull.outputs.success == 'false' }}
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone-testkrb5` workflow similar to the one for `ozone-runner`: publish multi-platform image to GitHub Container Registry.

Since this is an unsecure KDC only for testing, I propose to publish future updates only to GitHub Container Registry.  Existing image in Docker Hub needs to be retained for use by older Ozone versions.

https://issues.apache.org/jira/browse/HDDS-11632

## How was this patch tested?

Workflow runs:
- [build](https://github.com/adoroszlai/ozone-docker-testkrb5/actions/runs/11725544027/job/32662099802)
- [tag](https://github.com/adoroszlai/ozone-docker-testkrb5/actions/runs/11725601055/job/32662307834)

Verified the [image](https://github.com/adoroszlai/ozone-docker-testkrb5/pkgs/container/ozone-testkrb5/302019868?tag=test-HDDS-11632) published by executing a subset of `ozonesecure` tests.

```diff
diff --git hadoop-ozone/dist/pom.xml hadoop-ozone/dist/pom.xml
index b0fd526b80..ca01956939 100644
--- hadoop-ozone/dist/pom.xml
+++ hadoop-ozone/dist/pom.xml
@@ -29,7 +29,7 @@
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
     <docker.ozone-runner.version>20241104-jdk17-1</docker.ozone-runner.version>
-    <docker.ozone-testkr5b.image>apache/ozone-testkrb5:20230318-1</docker.ozone-testkr5b.image>
+    <docker.ozone-testkr5b.image>ghcr.io/adoroszlai/ozone-testkrb5:test-HDDS-11632</docker.ozone-testkr5b.image>
     <maven.test.skip>true</maven.test.skip> <!-- no tests in this module so far -->
   </properties>
 
```

```bash
$ hadoop-ozone/dist/src/main/keytabs/update-keytabs.sh
...
$ mvn -DskipTests -DskipShade clean package
$ cd hadoop-ozone/dist/target/ozone-2.0.0-SNAPSHOT/compose/ozonesecure
# edit test.sh, remove most tests
$ ./test.sh
...
Kinit :: Kinit test user                                              | PASS |
1 test, 1 passed, 0 failed
...
Basic Freon smoketest                                                 | PASS |
...
2 tests, 2 passed, 0 failed
```