### PR TITLE
HDDS-12441. Add helper script for building Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.asf.yaml
+build.sh
+CONTRIBUTING.md
+.git
+.github
+LICENSE
+NOTICE
+README.md
+SECURITY.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,66 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 # Contributing
 
-For detailed contribution guideline, please check the [contribution guideline of Apache Ozone repository](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
+For general contribution guideline, please check the [Apache Ozone repository](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
 
+Development of the `ozone-testkrb5` image happens on branch `master`.
+
+## Local Build and Test
+
+### Building
+
+The image can be built simply by running the helper script `build.sh`:
+
+```bash
+$ ./build.sh
+...
+ => => naming to docker.io/apache/ozone-testkrb5:dev
+```
+
+This will create a single-platform image for your architecture.
+
+### Testing
+
+To try the image locally with Ozone acceptance tests:
+
+1. Update `docker.ozone-testkr5b.image` to `<username>/ozone-testkrb5:<commit SHA>` in [hadoop-ozone/dist/pom.xml](https://github.com/apache/ozone/blob/bb16f66e22c44b360d42d0cae87024786e27c61b/hadoop-ozone/dist/pom.xml#L29).
+2. Rebuild Ozone.
+3. Run [acceptance tests](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/compose/README.md) as needed.
+
+## GitHub Workflows
+
+If this is your first time working on the image, please enable GitHub Actions workflows after forking the repo.
+
+### Building
+
+Whenever changes are pushed to your fork, GitHub builds a multi-platform image (for `amd64` and `arm64`), and tags it with the commit SHA.  These images can be shared with other developers for feedback.  Workflow runs are listed at `https://github.com/<username>/ozone-docker-testkrb5/actions`, images at `https://github.com/<username>/ozone-docker-testkrb5/pkgs/container/ozone-testkrb5`.
+
+### Testing
+
+To run complete Ozone CI with the custom image:
+
+1. Create a new branch in your clone of `apache/ozone`.
+2. Update `docker.ozone-testkr5b.image` as described above.
+3. Commit the change and push to your fork of `apache/ozone`.
+
+## Publishing Docker Tags (for committers)
+
+1. Fetch changes to your local clone.
+2. Add a Git tag for the commit following the existing pattern `<date>-<n>`, where `<n>` starts at 1, and is incremented if multiple images need to be published the same day.
+3. Push the Git tag to the official repo (`apache/ozone-docker-testkrb5`).  This will trigger a workflow to apply the tag to the Docker image.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
-# Containerized MIT Kerberos server for Ozone dev environments
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
-This repository contains the definition of a containerized MIT Kerberos server.
+      http://www.apache.org/licenses/LICENSE-2.0
 
-It's used for development and testing Apache Ozone and **not secured for production use**.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 
-Keytabs required by secure Ozone smoketests are pre-generated which makes possible to export them and store together with the containerized test environments. It makes the tests faster as the keytabs are already exported for each tests.
+# MIT Kerberos KDC for developing and testing Apache Ozone
 
+[ozone-testkrb5](https://github.com/apache/ozone-docker-testkrb5) is used as KDC for testing Apache Ozone with Kerberos enabled.
+
+Published only to [GitHub](https://github.com/apache/ozone-docker-testkrb5/pkgs/container/ozone-testkrb5), because it is completely insecure, and should be used only for testing, **not for production**.
+
+Images are tagged by date.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu -o pipefail
+
+docker build -t apache/ozone-testkrb5:dev "$@" .


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `build.sh`, helper script for building the image.

Benefits:

- consistent experience across `ozone-docker*` repos
- future improvements possible without updating docs

Also add `.dockerignore`.

https://issues.apache.org/jira/browse/HDDS-12441

## How was this patch tested?

```bash
$ ./build.sh
...
 => => naming to docker.io/apache/ozone-testkrb5:dev
```

CI:
https://github.com/adoroszlai/ozone-docker-testkrb5/actions/runs/13588513265