### PR TITLE
HDDS-12466. Set commit message to PR title

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,7 @@ github:
     - unsecure
   enabled_merge_buttons:
     squash:  true
+    squash_commit_message: PR_TITLE
     merge:   false
     rebase:  false
 notifications:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set default commit message to the PR title during merge.  The title can still be edited if needed, but hopefully this avoids picking up single commit's possibly bad message.

ref: https://github.com/apache/infrastructure-asfyaml/tree/ng-parser?tab=readme-ov-file#merge-buttons

https://issues.apache.org/jira/browse/HDDS-12466

## How was this patch tested?

Will be tested by test PR once this is merged.  If all is OK, we can apply the same changes to other repos.
