### PR TITLE
HDDS-14833. Bump GitHub action versions

### DIFF
--- a/.github/workflows/build-and-tag.yaml
+++ b/.github/workflows/build-and-tag.yaml
@@ -36,7 +36,7 @@ jobs:
       IMAGE_ID: ${{ needs.build.outputs.image-id }}
     steps:
       - name: Generate tags
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/ozone-testkrb5
@@ -50,7 +50,7 @@ jobs:
           docker pull "$IMAGE_ID"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Generate image ID
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/ozone-testkrb5
@@ -64,16 +64,16 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Set up Docker Buildx
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to GitHub Container Registry
         id: login
         if: ${{ github.event_name != 'pull_request' && steps.pull.outputs.success == 'false' }}
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -82,7 +82,7 @@ jobs:
       - name: Build and push image to GitHub Container Registry
         id: build
         if: ${{ steps.pull.outputs.success == 'false' }}
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Node.js 20 is [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) in GitHub runners.  Bump GitHub actions versions to the latest ones for Node.js 24 support.

https://issues.apache.org/jira/browse/HDDS-14833

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone-docker-testkrb5/actions/runs/23426888387

Verified that all workflows use the same versions:

```bash
$ grep --no-filename -- '-action' .github/workflows/*.* | sed 's/^.*uses: //' | sort -u
docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
```

and they match the ones in `ozone-docker` and `ozone-docker-runner`.

```bash
$ diff -q \
    <(grep --no-filename -- '-action' .github/workflows/*.* | sed 's/^.*uses: //' | sort -u) \
    <(grep --no-filename -- '-action' ../ozone-docker/.github/workflows/*.* | sed 's/^.*uses: //' | sort -u)
```