### PR TITLE
HDDS-15725. zizmor check should reflect failure in fork

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,9 +21,17 @@ on:
       - 'dependabot/**'
     tags:
       - '**'
+    paths:
+      - '.github/workflows/**'
   pull_request:
+    paths:
+      - '.github/workflows/**'
 
 permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
 
 jobs:
   zizmor:
@@ -38,3 +46,5 @@ jobs:
 
     - name: Run zizmor
       uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      with:
+        advanced-security: ${{ github.repository_owner == 'apache' }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

zizmor workflow added in HDDS-14920 provides feedback via "Code scanning results".  The workflow itself passes even if it finds issues to be fixed.  This does not work well in forks where code scanning is disabled.

Additional minor tweak:
- run zizmor check only for workflow changes

Also adopts the following change from other Ozone repos:
- HDDS-15527. Cancel superseded PR runs

https://issues.apache.org/jira/browse/HDDS-15725

## How was this patch tested?

Tested in `ozone` repo:

Without the patch passes despite intentional violation:
https://github.com/adoroszlai/ozone/actions/runs/28570405264/job/84706670204#step:3:1058

Same violation with the patch fails:
https://github.com/adoroszlai/ozone/actions/runs/28570585965/job/84707233189#step:3:208

The patch without intentional violation passes (also in this repo):
https://github.com/adoroszlai/ozone/actions/runs/28570809169/job/84707932173#step:3:107
https://github.com/adoroszlai/ozone-docker-testkrb5/actions/runs/28587541546